### PR TITLE
MemberValidator interface -> abstract로 변경

### DIFF
--- a/src/main/java/project/study/domain/Member.java
+++ b/src/main/java/project/study/domain/Member.java
@@ -49,6 +49,13 @@ public class Member implements ImageFileEntity {
     public void changeStatusToNormal() {
         memberStatus = MemberStatusEnum.정상;
     }
+    public void changeStatusToExpire() {
+        this.memberStatus = MemberStatusEnum.탈퇴;
+        this.memberExpireDate = LocalDateTime.now();
+    }
+    public void changeStatusToFreeze() {
+        this.memberStatus = MemberStatusEnum.이용정지;
+    }
     public boolean isFreezeMember() {
         return memberStatus.isFreezeMember();
     }
@@ -104,11 +111,6 @@ public class Member implements ImageFileEntity {
     public void setImage(String originalName, String storeName) {
         if (profile == null) return;
         profile.setImage(originalName, storeName);
-    }
-
-    public void changeStatusToExpire() {
-        this.memberStatus = MemberStatusEnum.탈퇴;
-        this.memberExpireDate = LocalDateTime.now();
     }
 
     public int joinRoomCount(AuthorityMemberEnum authorityEnum) {

--- a/src/main/java/project/study/dto/login/validator/MemberValidator.java
+++ b/src/main/java/project/study/dto/login/validator/MemberValidator.java
@@ -1,13 +1,42 @@
 package project.study.dto.login.validator;
 
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import project.study.domain.Freeze;
 import project.study.domain.Member;
-import project.study.dto.login.requestdto.RequestLoginDto;
 import project.study.dto.login.requestdto.RequestSignupDto;
+import project.study.repository.FreezeRepository;
 
-public interface MemberValidator {
+import java.util.Optional;
 
-    void validLogin(Member member, HttpServletResponse response);
+@Component
+@RequiredArgsConstructor
+public abstract class MemberValidator {
 
-    void validSignup(RequestSignupDto signupDto);
+    private final FreezeRepository freezeRepository;
+
+    public void validLogin(Member member, HttpServletResponse response) {
+        System.out.println("회원 검증 로직 시작");
+        // 이용정지 회원인지 확인
+        if (member.isExpireMember()) {
+            expireMemberLoginException(response); // 탈퇴한 회원인지 확인
+        }
+        if(!member.isFreezeMember()) return; // 이용정지된 회원이 아님
+
+        Optional<Freeze> findFreeze = freezeRepository.findByMemberId(member.getMemberId());
+        if (findFreeze.isEmpty()) return; // Freeze Entity 없음 ( 혹시 모를 예외 처리 )
+
+        Freeze freeze = findFreeze.get();
+        if (freeze.isFinish()) { // Freeze Entity는 존재하지만 이용정지 기간에 풀린 경우
+            freezeRepository.delete(freeze, member);
+            return;
+        }
+        freezeMemberLoginException(freeze, response); // 모든 조건에 걸리지 않은 회원은 이용정지 회원임.
+    }
+
+    abstract void expireMemberLoginException(HttpServletResponse response);
+    abstract void freezeMemberLoginException(Freeze freeze, HttpServletResponse response);
+
+    public abstract void validSignup(RequestSignupDto signupDto);
 }

--- a/src/test/java/project/study/domain/MockRoom.java
+++ b/src/test/java/project/study/domain/MockRoom.java
@@ -8,12 +8,9 @@ import org.springframework.transaction.annotation.Transactional;
 import project.study.enums.AuthorityMemberEnum;
 import project.study.enums.MemberStatusEnum;
 import project.study.enums.PublicEnum;
-import project.study.jpaRepository.JoinRoomJpaRepository;
 import project.study.jpaRepository.RoomJpaRepository;
-import project.study.jpaRepository.TagJpaRepository;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 
@@ -84,7 +81,7 @@ public class MockRoom {
             if (count == 0) return this;
 
             for (int i = 0; i < count; i++) {
-                Member member = mockMember.createBasicMember(MemberStatusEnum.정상);
+                Member member = mockMember.createMember().setBasic().build();
                 em.persist(createJoinRoom(i, member));
             }
             return this;

--- a/src/test/java/project/study/repository/MypageRepositoryTest.java
+++ b/src/test/java/project/study/repository/MypageRepositoryTest.java
@@ -10,12 +10,11 @@ import project.study.domain.Member;
 import project.study.domain.MockMember;
 import project.study.dto.login.responsedto.ErrorList;
 import project.study.dto.mypage.RequestChangePasswordDto;
-import project.study.enums.MemberStatusEnum;
-import project.study.enums.SocialEnum;
 import project.study.exceptions.RestFulException;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static project.study.enums.MemberStatusEnum.*;
 import static project.study.enums.SocialEnum.KAKAO;
 
@@ -32,7 +31,7 @@ class MypageRepositoryTest {
     @Test
     @DisplayName("소셜 회원은 비밀번호를 변경할 수 없다.")
     void validChangePassword() {
-        Member socialMember = mockMember.createSocialMember(정상, KAKAO);
+        Member socialMember = mockMember.createMember().setSocial(KAKAO).build();
 
         Assertions.assertThatThrownBy(() -> mypageRepository.validChangePassword(socialMember, null, new ErrorList()))
             .isInstanceOf(RestFulException.class);
@@ -42,7 +41,7 @@ class MypageRepositoryTest {
     @DisplayName("일반 회원 비밀번호 변경")
     void validNickname() {
         // given
-        Member basicMember = mockMember.createBasicMember(정상);
+        Member basicMember = mockMember.createMember().setBasic().build();
         ErrorList errorList0 = new ErrorList();
         ErrorList errorList1 = new ErrorList();
         ErrorList errorList2 = new ErrorList();
@@ -89,7 +88,7 @@ class MypageRepositoryTest {
     @DisplayName("소셜회원은 회원탈퇴 시 비밀번호가 필요하지 않다.")
     void validDeleteSocialMember() {
         // given
-        Member socialMember = mockMember.createSocialMember(정상, KAKAO);
+        Member socialMember = mockMember.createMember().setSocial(KAKAO).build();
 
         // then
         assertThatCode(() -> mypageRepository.validDeleteMember(socialMember, null))
@@ -100,7 +99,7 @@ class MypageRepositoryTest {
     @DisplayName("일반회원은 회원탈퇴 시 비밀번호가 일치하여야 한다.")
     void validDeleteBasicMember() {
         // given
-        Member basicMember = mockMember.createBasicMember(정상);
+        Member basicMember = mockMember.createMember().setBasic().build();
 
         // then
         assertThatThrownBy(() -> mypageRepository.validDeleteMember(basicMember, "invalidPassword"))
@@ -114,12 +113,12 @@ class MypageRepositoryTest {
     void validMember() {
 
         // given
-        Member validMember1 = mockMember.createSocialMember(정상, KAKAO);
-        Member validMember2 = mockMember.createBasicMember(정상);
-        Member inValidMember3 = mockMember.createSocialMember(탈퇴, KAKAO);
-        Member inValidMember4 = mockMember.createSocialMember(이용정지, KAKAO);
-        Member inValidMember5 = mockMember.createBasicMember(이용정지);
-        Member inValidMember6 = mockMember.createBasicMember(탈퇴);
+        Member validMember1 = mockMember.createMember().setSocial(KAKAO).build();
+        Member validMember2 = mockMember.createMember().setBasic().build();
+        Member inValidMember3 = mockMember.createMember().setSocial(KAKAO).setExpire().build();
+        Member inValidMember4 = mockMember.createMember().setSocial(KAKAO).setFreeze(LocalDateTime.now().plusDays(1)).build();
+        Member inValidMember5 = mockMember.createMember().setBasic().setFreeze(LocalDateTime.now().plusDays(1)).build();
+        Member inValidMember6 = mockMember.createMember().setBasic().setExpire().build();
 
         // 정상로직
         assertThatCode(() -> mypageRepository.validMember(validMember1, new ErrorList()))

--- a/src/test/java/project/study/service/BasicLoginServiceTest.java
+++ b/src/test/java/project/study/service/BasicLoginServiceTest.java
@@ -1,0 +1,129 @@
+package project.study.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.transaction.annotation.Transactional;
+import project.study.constant.WebConst;
+import project.study.domain.Freeze;
+import project.study.domain.Member;
+import project.study.domain.MockMember;
+import project.study.dto.login.requestdto.RequestDefaultLoginDto;
+import project.study.exceptions.login.ExpireMemberLoginException;
+import project.study.exceptions.login.FreezeMemberLoginException;
+import project.study.jpaRepository.FreezeJpaRepository;
+import project.study.jpaRepository.MemberJpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static project.study.enums.MemberStatusEnum.*;
+
+@SpringBootTest
+@Transactional
+class BasicLoginServiceTest {
+
+    @Autowired
+    private LoginService loginService;
+    @Autowired
+    private MockMember mockMember;
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
+    @Autowired
+    private FreezeJpaRepository freezeJpaRepository;
+
+    @Test
+    @DisplayName("일반회원 로그인 정상흐름")
+    void basicMemberLoginValid() {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpSession session = new MockHttpSession();
+        // 정상적인 회원
+        Member basicMember = mockMember.createMember().setBasic().build();
+
+        RequestDefaultLoginDto data = new RequestDefaultLoginDto();
+        data.setAccount("test" + (basicMember.getMemberId() - 1));
+        data.setPassword("!@#QWEasd" + (basicMember.getMemberId() - 1));
+
+        // when
+        loginService.login(data, session, response);
+        Long loginMemberId = (Long) session.getAttribute(WebConst.LOGIN_MEMBER);
+
+        // then
+        assertThat(loginMemberId).isEqualTo(basicMember.getMemberId());
+    }
+
+    @Test
+    @DisplayName("이용정지된 회원은 로그인할 수 없다")
+    void basicMemberLoginInValid1() {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpSession session = new MockHttpSession();
+        // 이용정지기간이 하루 남은 회원
+        Member basicMember = mockMember.createMember().setBasic().setFreeze(LocalDateTime.now().plusDays(1)).build();
+
+        RequestDefaultLoginDto data = new RequestDefaultLoginDto();
+        data.setAccount("test" + (basicMember.getMemberId() - 1));
+        data.setPassword("!@#QWEasd" + (basicMember.getMemberId() - 1));
+
+        // when
+        assertThatThrownBy(() -> loginService.login(data, session, response))
+            .isInstanceOf(FreezeMemberLoginException.class);
+    }
+
+    @Test
+    @DisplayName("이용정지 기간이 종료된 회원은 로그인할 수 있다")
+    void basicMemberLoginInValid2() {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpSession session = new MockHttpSession();
+        // 이용정지기간이 어제까지였던 회원
+        Member basicMember = mockMember.createMember().setBasic().setFreeze(LocalDateTime.now().minusDays(1)).build();
+
+        RequestDefaultLoginDto data = new RequestDefaultLoginDto();
+        data.setAccount("test" + (basicMember.getMemberId() - 1));
+        data.setPassword("!@#QWEasd" + (basicMember.getMemberId() - 1));
+
+        // 로그인 이전까지는 이용정지가 지속되어야한다.
+        assertThat(basicMember.isFreezeMember()).isTrue();
+        Optional<Freeze> beforeFreeze = freezeJpaRepository.findByMember_MemberId(basicMember.getMemberId());
+        assertThat(beforeFreeze.isPresent()).isTrue();
+
+        // 예외가 안나야한다.
+        assertThatCode(() -> loginService.login(data, session, response))
+            .doesNotThrowAnyException();
+
+        // 이용정지가 해제되었다.
+        assertThat(basicMember.isFreezeMember()).isFalse();
+        Optional<Freeze> afterFreeze = freezeJpaRepository.findByMember_MemberId(basicMember.getMemberId());
+        assertThat(afterFreeze.isEmpty()).isTrue();
+
+    }
+    @Test
+    @DisplayName("탈퇴한 회원은 로그인할 수 없다")
+    void basicMemberLoginInValid3() {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpSession session = new MockHttpSession();
+        Member basicMember = mockMember.createMember().setBasic().setExpire().build();
+
+        RequestDefaultLoginDto data = new RequestDefaultLoginDto();
+        data.setAccount("test" + (basicMember.getMemberId() - 1));
+        data.setPassword("!@#QWEasd" + (basicMember.getMemberId() - 1));
+
+        // when
+        assertThatThrownBy(() -> loginService.login(data, session, response))
+            .isInstanceOf(ExpireMemberLoginException.class);
+    }
+
+
+
+
+    @Test
+    void basicMemberSignup() {
+    }
+}


### PR DESCRIPTION
login 로직에서  일반회원과 소셜회원의 예외 이외 로직은 공통로직입니다.

회원에의 탈퇴,정지 여부는 모든 회원에게 동일한 로직을 부여해야하는만큼 같은 로직을 반복하는 것은 차후  일관성을 위반하는 행위로 이어지는 만큼 interface -> abstract로 변경했습니다.

예외로직은 abstract method를 이용해 상속받은 구현체에서 구현체에 맞는 예외로직을 추가해주는 것으로 로그인 검증 로직을 공통화 시킬 수 있었습니다.